### PR TITLE
Delay screen scroll fix and TOC text changes

### DIFF
--- a/Cookbook/Cookbook/ContentView.swift
+++ b/Cookbook/Cookbook/ContentView.swift
@@ -23,7 +23,7 @@ struct MasterView: View {
                     NavigationLink(destination: MusicToyView()) { Text("Music Toy") }
                     NavigationLink(destination: Telephone()) { Text("Telephone") }
                     NavigationLink(destination: TunerView()) { Text("Tuner") }
-                    NavigationLink(destination: NoiseGeneratorsView()) { Text("Noise Generator") }
+                    NavigationLink(destination: NoiseGeneratorsView()) { Text("Noise Generators") }
                     NavigationLink(destination: VocalTractView()) { Text("Vocal Tract") }
                     NavigationLink(destination: MIDIMonitorView()) { Text("MIDI Monitor") }
                     NavigationLink(destination: RecorderView()) { Text("Recorder") }
@@ -35,7 +35,7 @@ struct MasterView: View {
             }
 
             Section(header: Text("Operations")) {
-                NavigationLink(destination: VocalTractOperationView()) { Text("Vocal Tract") }
+                NavigationLink(destination: VocalTractOperationView()) { Text("Vocal Fun") }
             }
 
             Section(header: Text("Effects")) {

--- a/Cookbook/Cookbook/Recipes/Delay.swift
+++ b/Cookbook/Cookbook/Recipes/Delay.swift
@@ -118,9 +118,3 @@ struct DelayView: View {
         }
     }
 }
-
-struct Delay_Previews: PreviewProvider {
-    static var previews: some View {
-        /*@START_MENU_TOKEN@*/Text("Hello, World!")/*@END_MENU_TOKEN@*/
-    }
-}

--- a/Cookbook/Cookbook/Recipes/Delay.swift
+++ b/Cookbook/Cookbook/Recipes/Delay.swift
@@ -92,7 +92,7 @@ struct DelayView: View {
     @ObservedObject var conductor = DelayConductor()
 
     var body: some View {
-        VStack {
+        ScrollView {
             PlayerControls(conductor: conductor)
             ParameterSlider(text: "Time",
                             parameter: self.$conductor.data.time,
@@ -116,5 +116,11 @@ struct DelayView: View {
         .onDisappear {
             self.conductor.stop()
         }
+    }
+}
+
+struct Delay_Previews: PreviewProvider {
+    static var previews: some View {
+        /*@START_MENU_TOKEN@*/Text("Hello, World!")/*@END_MENU_TOKEN@*/
     }
 }


### PR DESCRIPTION
1. Changed the Delay screen's VStack to Scrollable, so that it functions as expected, and so that the "Time" label doesn't overlap with the "Delay" navigation bar title.
2. Changed the Table of Contents titles (Noise Generators and Vocal Fun) to match their screen titles.


### Delay bug:
<img src="https://user-images.githubusercontent.com/1577928/95383486-1977c000-08a0-11eb-9567-98e2477d94d6.jpeg" width="50%" height="50%">

### Delay fix:
<img src="https://user-images.githubusercontent.com/1577928/95384678-cdc61600-08a1-11eb-9cd7-b8f2252d1a74.jpeg" width="50%" height="50%">

### Updated Titles:
<img src="https://user-images.githubusercontent.com/1577928/95383557-33b19e00-08a0-11eb-93c1-d09d67ef1798.jpeg" width="50%" height="50%">




