### PR TITLE
Optimized PlayerControl layout

### DIFF
--- a/Cookbook/Cookbook/Recipes/Reverb.swift
+++ b/Cookbook/Cookbook/Recipes/Reverb.swift
@@ -52,6 +52,7 @@ struct ReverbView: View {
                     Text("Small Room").onTapGesture { conductor.reverb.loadFactoryPreset(.smallRoom) }
                 }
             }
+            Spacer()
         }
         .padding()
         .navigationBarTitle(Text("Apple Reverb"))

--- a/Cookbook/Cookbook/Reusable Components/PlayerControls.swift
+++ b/Cookbook/Cookbook/Reusable Components/PlayerControls.swift
@@ -60,7 +60,7 @@ struct PlayerControls: View {
                 .cornerRadius(25.0)
                 .shadow(color: ColorManager.accentColor.opacity(0.4), radius: 5, x: 0.0, y: 3)
         }
-        .frame(minWidth: 300, idealWidth: 350, maxWidth: 360, minHeight: 50, idealHeight: 50, maxHeight: 60, alignment: .center)
+        .frame(minWidth: 300, idealWidth: 350, maxWidth: 360, minHeight: 50, idealHeight: 50, maxHeight: 50, alignment: .center)
         .padding()
         .sheet(isPresented: $isShowingSources,
                onDismiss: { print("finished!") },

--- a/Cookbook/Cookbook/Reusable Components/PlayerControls.swift
+++ b/Cookbook/Cookbook/Reusable Components/PlayerControls.swift
@@ -28,10 +28,10 @@ struct PlayerControls: View {
     @State var isShowingSources = false
 
     var body: some View {
-        HStack {
+        HStack(spacing: 10) {
             ZStack {
                 LinearGradient(gradient: Gradient(colors: [.blue, .accentColor]), startPoint: .top, endPoint: .bottom)
-                    .cornerRadius(20.0)
+                    .cornerRadius(25.0)
                     .shadow(color: ColorManager.accentColor.opacity(0.4), radius: 5, x: 0.0, y: 3)
 
                 HStack {
@@ -47,8 +47,9 @@ struct PlayerControls: View {
             }
 
             Button(action: {
-                self.isPlaying ? self.conductor.player.pause() : self.conductor.player.play()
+                self.isPlaying ? self.conductor.player.stop() : self.conductor.player.play()
                 self.isPlaying.toggle()
+                print("\(self.isPlaying)")
             }, label: {
                 Image(systemName: isPlaying ? "stop.fill" : "play.fill")
             })
@@ -56,9 +57,10 @@ struct PlayerControls: View {
                 .background(isPlaying ? Color.red : Color.green)
                 .foregroundColor(.white)
                 .font(.system(size: 14, weight: .semibold, design: .rounded))
-                .cornerRadius(20.0)
+                .cornerRadius(25.0)
                 .shadow(color: ColorManager.accentColor.opacity(0.4), radius: 5, x: 0.0, y: 3)
         }
+        .frame(minWidth: 300, idealWidth: 350, maxWidth: 360, minHeight: 50, idealHeight: 50, maxHeight: 60, alignment: .center)
         .padding()
         .sheet(isPresented: $isShowingSources,
                onDismiss: { print("finished!") },

--- a/Cookbook/Cookbook/Reusable Components/PlayerControls.swift
+++ b/Cookbook/Cookbook/Reusable Components/PlayerControls.swift
@@ -49,7 +49,6 @@ struct PlayerControls: View {
             Button(action: {
                 self.isPlaying ? self.conductor.player.stop() : self.conductor.player.play()
                 self.isPlaying.toggle()
-                print("\(self.isPlaying)")
             }, label: {
                 Image(systemName: isPlaying ? "stop.fill" : "play.fill")
             })


### PR DESCRIPTION
1. Fixed the PlayerControl's layout, so that it didn't appear too tall.
2. Changed the play button toggle from `pause()` to `stop()`, because toggling play wouldn't continue the audio loop from where it was paused. So, when you tapped the play button, the audio loop wouldn't play until you stopped it, and started it again.

Here's how it looks, now:

<img src="https://user-images.githubusercontent.com/1577928/118390061-f81f4500-b5e1-11eb-9c72-98773c73c938.jpeg" width="50%" height="50%" />

Here's how it looks with the fix:

<img src="https://user-images.githubusercontent.com/1577928/118390071-066d6100-b5e2-11eb-8329-5f203ad8d876.jpeg" width="50%" height="50%" />

