### PR TITLE
Replace swiftui-sliders lib with native SwiftUI Slider

### DIFF
--- a/Cookbook/Cookbook.xcodeproj/project.pbxproj
+++ b/Cookbook/Cookbook.xcodeproj/project.pbxproj
@@ -142,7 +142,6 @@
 		C446DF262528D9CA00138D0A /* ADSRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C446DEB32528D9CA00138D0A /* ADSRView.swift */; };
 		C446DF2B2528D9CA00138D0A /* PlotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C446DEB62528D9CA00138D0A /* PlotView.swift */; };
 		C446DF2C2528D9CA00138D0A /* PlotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C446DEB62528D9CA00138D0A /* PlotView.swift */; };
-		C446DF392528DA4400138D0A /* Sliders in Frameworks */ = {isa = PBXBuildFile; productRef = C446DF382528DA4400138D0A /* Sliders */; };
 		C446E0272528FD7C00138D0A /* Samples in Resources */ = {isa = PBXBuildFile; fileRef = C446E0252528FD7B00138D0A /* Samples */; };
 		C446E0282528FD7C00138D0A /* Samples in Resources */ = {isa = PBXBuildFile; fileRef = C446E0252528FD7B00138D0A /* Samples */; };
 		C446E0292528FD7C00138D0A /* Sounds in Resources */ = {isa = PBXBuildFile; fileRef = C446E0262528FD7C00138D0A /* Sounds */; };
@@ -317,7 +316,6 @@
 			files = (
 				B18A164325564B67000A8689 /* AudioKit in Frameworks */,
 				C42F77B2258F291B000270CD /* AudioKitUI in Frameworks */,
-				C446DF392528DA4400138D0A /* Sliders in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -542,7 +540,6 @@
 			);
 			name = Cookbook;
 			packageProductDependencies = (
-				C446DF382528DA4400138D0A /* Sliders */,
 				B18A164225564B67000A8689 /* AudioKit */,
 				C42F77B1258F291B000270CD /* AudioKitUI */,
 			);
@@ -596,7 +593,6 @@
 			);
 			mainGroup = C446DE3B2528D8E600138D0A;
 			packageReferences = (
-				C446DF372528DA4400138D0A /* XCRemoteSwiftPackageReference "swiftui-sliders" */,
 				B18A164125564B67000A8689 /* XCRemoteSwiftPackageReference "AudioKit" */,
 				C42F77B0258F291B000270CD /* XCRemoteSwiftPackageReference "AudioKitUI" */,
 			);
@@ -1090,14 +1086,6 @@
 				kind = branch;
 			};
 		};
-		C446DF372528DA4400138D0A /* XCRemoteSwiftPackageReference "swiftui-sliders" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/spacenation/swiftui-sliders";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1110,11 +1098,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = C42F77B0258F291B000270CD /* XCRemoteSwiftPackageReference "AudioKitUI" */;
 			productName = AudioKitUI;
-		};
-		C446DF382528DA4400138D0A /* Sliders */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C446DF372528DA4400138D0A /* XCRemoteSwiftPackageReference "swiftui-sliders" */;
-			productName = Sliders;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cookbook/Cookbook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cookbook/Cookbook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -18,15 +18,6 @@
           "revision": "2ebf38e34c4c9f837ae65190c04fa13984d2f914",
           "version": null
         }
-      },
-      {
-        "package": "Sliders",
-        "repositoryURL": "https://github.com/spacenation/swiftui-sliders",
-        "state": {
-          "branch": null,
-          "revision": "5109792d45a53c3c41680b8bdb0602b5dde39c9a",
-          "version": "1.0.0"
-        }
       }
     ]
   },

--- a/Cookbook/Cookbook/Reusable Components/ParameterSlider.swift
+++ b/Cookbook/Cookbook/Reusable Components/ParameterSlider.swift
@@ -1,6 +1,5 @@
 import AVFoundation
 import SwiftUI
-import Sliders
 
 struct ParameterSlider: View {
     var text: String
@@ -26,10 +25,7 @@ struct ParameterSlider: View {
                     Text("\(self.parameter, specifier: self.format) \(units)")
                 }
             }
-            ValueSlider(value: self.$parameter, in: self.range)
-                .valueSliderStyle(HorizontalValueSliderStyle(
-                    thumbSize: CGSize(width: 20, height: 20),
-                    thumbInteractiveSize: CGSize(width: 44, height: 44)))
+            Slider(value: self.$parameter, in: self.range)
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/AudioKit/Cookbook/issues/32 - seems like a bug in the library where the slider thumb becomes unresponsive

Looks slightly different but probably better as matches native look and feel now

Before:

![image](https://user-images.githubusercontent.com/5458070/119872643-9df47d00-bf1b-11eb-86b3-30867e511bc5.png)

After:

![image](https://user-images.githubusercontent.com/5458070/119872436-61c11c80-bf1b-11eb-988c-1a3d199756df.png)
