### PR TITLE
Add Playlist Demo with AudioPlayer

### DIFF
--- a/Cookbook/Cookbook.xcodeproj/project.pbxproj
+++ b/Cookbook/Cookbook.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		074B97A426604E0A008051E8 /* MIDIPortTestConductor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074B97A326604E0A008051E8 /* MIDIPortTestConductor.swift */; };
 		074B97A526604E0A008051E8 /* MIDIPortTestConductor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 074B97A326604E0A008051E8 /* MIDIPortTestConductor.swift */; };
 		07A1D09626546D8000238530 /* TransientShaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07A1D09526546D7F00238530 /* TransientShaper.swift */; };
+		07EDAAAB26B71F1500F40920 /* Playlist.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07EDAAAA26B71F1500F40920 /* Playlist.swift */; };
 		176E7F1E25380CAF00602020 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 176E7F1D25380CAF00602020 /* Colors.xcassets */; };
 		176E7F2425380DB800602020 /* ColorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176E7F2325380DB800602020 /* ColorManager.swift */; };
 		176E7F2C253A13AB00602020 /* SplashView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 176E7F2B253A13AA00602020 /* SplashView.swift */; };
@@ -205,6 +206,7 @@
 		074B97992660241E008051E8 /* MIDIPortTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIPortTest.swift; sourceTree = "<group>"; };
 		074B97A326604E0A008051E8 /* MIDIPortTestConductor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MIDIPortTestConductor.swift; sourceTree = "<group>"; };
 		07A1D09526546D7F00238530 /* TransientShaper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TransientShaper.swift; sourceTree = "<group>"; };
+		07EDAAAA26B71F1500F40920 /* Playlist.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Playlist.swift; sourceTree = "<group>"; };
 		176E7F1D25380CAF00602020 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		176E7F2325380DB800602020 /* ColorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorManager.swift; sourceTree = "<group>"; };
 		176E7F2B253A13AA00602020 /* SplashView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashView.swift; sourceTree = "<group>"; };
@@ -485,6 +487,7 @@
 				C47A3AA925329801005A98BA /* PitchShfitOperation.swift */,
 				C446DE842528D9CA00138D0A /* PitchShifter.swift */,
 				C40936362535091F0082AF9F /* PlaybackSpeed.swift */,
+				07EDAAAA26B71F1500F40920 /* Playlist.swift */,
 				22FCFDC42603C99300526754 /* PluckedString.swift */,
 				C446DE7D2528D9CA00138D0A /* PWMOscillator.swift */,
 				C446DE832528D9CA00138D0A /* Recorder.swift */,
@@ -737,6 +740,7 @@
 				C4E399F625329D31008DA7F0 /* DrippingSounds.swift in Sources */,
 				C47A3A9E253287EE005A98BA /* LowShelfFilter.swift in Sources */,
 				C446DF072528D9CA00138D0A /* AutoWah.swift in Sources */,
+				07EDAAAB26B71F1500F40920 /* Playlist.swift in Sources */,
 				C47A3A9225327EF7005A98BA /* Flanger.swift in Sources */,
 				C4E39A0A2532CC8E008DA7F0 /* DrumSynthesizers.swift in Sources */,
 				C47A3A962532801E005A98BA /* HighShelfFilter.swift in Sources */,

--- a/Cookbook/Cookbook/ContentView.swift
+++ b/Cookbook/Cookbook/ContentView.swift
@@ -21,6 +21,7 @@ struct MasterView: View {
                 NavigationLink(destination: DynamicOscillatorView()) { Text("Dynamic Oscillator") }
                 NavigationLink(destination: MIDIPortTestView()) { Text("MIDI Port Test") }
                 NavigationLink(destination: InputDeviceDemoView()) { Text("Input Device Demo") }
+                NavigationLink(destination: PlaylistView()) { Text("Playlist") }
             }
             Section(header: Text("Mini Apps")
                         .padding(.top, 20)) {

--- a/Cookbook/Cookbook/Cookbook.entitlements
+++ b/Cookbook/Cookbook/Cookbook.entitlements
@@ -6,6 +6,8 @@
 	<true/>
 	<key>com.apple.security.device.audio-input</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
 </dict>

--- a/Cookbook/Cookbook/Recipes/Playlist.swift
+++ b/Cookbook/Cookbook/Recipes/Playlist.swift
@@ -39,7 +39,12 @@ class PlaylistConductor: ObservableObject {
                     else { return }
 
                     if supertypes.contains(.audio) {
-                        self.audioFileList.append(PlayerFile(url: item, name: item.deletingPathExtension().lastPathComponent))
+                        self.audioFileList.append(
+                            PlayerFile(
+                                url: item,
+                                name: item.deletingPathExtension().lastPathComponent
+                            )
+                        )
                     }
                 } catch {
                     Log(error.localizedDescription, type: .error)
@@ -65,7 +70,7 @@ class PlaylistConductor: ObservableObject {
         engine.stop()
     }
 }
-struct PlaylistView : View {
+struct PlaylistView: View {
     @State var openFile = false
     @StateObject var conductor = PlaylistConductor()
     @State var fileName = ""
@@ -109,9 +114,7 @@ struct PlaylistView : View {
             // Stop the audio engine when the view disappears
             conductor.stop()
         }
-        .fileImporter(isPresented: $openFile,
-                      allowedContentTypes: [.folder])
-        { res in
+        .fileImporter(isPresented: $openFile, allowedContentTypes: [.folder]) { res in
             // Get the files in user-selected folder when $openFile is true
             do {
                 let folderURL = try res.get()

--- a/Cookbook/Cookbook/Recipes/Playlist.swift
+++ b/Cookbook/Cookbook/Recipes/Playlist.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+import AudioKit
+import UniformTypeIdentifiers
+
+struct PlayerFile: Identifiable, Hashable {
+    let id = UUID()
+    let url: URL
+    let name: String
+}
+struct PlayerFileItem: View {
+    var playerFile: PlayerFile
+    var body: some View {
+        Text(playerFile.name)
+    }
+}
+class PlaylistConductor: ObservableObject {
+    let engine = AudioEngine()
+    var audioFileList = [PlayerFile]()
+    var player = AudioPlayer()
+
+    init() {
+        engine.output = player
+    }
+
+    // Find all the audio files in a user-selected folder
+    func getPlayableFolderFiles(inFolderURL: URL) {
+        do {
+            let fileManager = FileManager.default
+            let items = try fileManager.contentsOfDirectory(at: inFolderURL,
+                                                            includingPropertiesForKeys: nil)
+
+            for item in items {
+                do {
+                    guard let typeID = try item.resourceValues(forKeys:
+                                                                [.typeIdentifierKey]).typeIdentifier
+                    else { return }
+
+                    guard let supertypes = UTType(typeID)?.supertypes
+                    else { return }
+
+                    if supertypes.contains(.audio) {
+                        self.audioFileList.append(PlayerFile(url: item, name: item.deletingPathExtension().lastPathComponent))
+                    }
+                } catch {
+                    Log(error.localizedDescription, type: .error)
+                }
+            }
+        } catch {
+            Log(error.localizedDescription, type: .error)
+        }
+    }
+
+    // Player functions
+    func loadFile(url: URL) {
+        do {
+            try player.load(url: url)
+        } catch {
+            Log(error.localizedDescription, type: .error)
+        }
+    }
+    func start() {
+        do { try engine.start() } catch let err { Log(err) }
+    }
+    func stop() {
+        engine.stop()
+    }
+}
+struct PlaylistView : View {
+    @State var openFile = false
+    @StateObject var conductor = PlaylistConductor()
+    @State var fileName = ""
+
+    var body: some View {
+        VStack(spacing: 25) {
+            // Button to let user select the folder for their playlist
+            Button(action: {openFile.toggle()},
+                   label: {
+                Text("Select Playlist Folder")
+            })
+
+            Text("Click on file below to play...")
+
+            // View with audio files contained in the selected folder (makes a playlist)
+            ScrollView {
+                VStack(spacing: 20) {
+                    ForEach(conductor.audioFileList, id: \.self) { audioFile in
+                        Button(action: {
+                            try? conductor.player.load(url: audioFile.url)
+                            fileName = audioFile.name
+                            conductor.player.play()
+                        }) {
+                            HStack {
+                                Text(audioFile.name)
+                                Spacer()
+                                if fileName == audioFile.name {
+                                    Image(systemName: "play")
+                                }
+                            }.padding()
+                        }
+                    }
+                }
+            }
+        }
+        .onAppear {
+            // Start the audio engine when the view appears
+            conductor.start()
+        }
+        .onDisappear {
+            // Stop the audio engine when the view disappears
+            conductor.stop()
+        }
+        .fileImporter(isPresented: $openFile,
+                      allowedContentTypes: [.folder])
+        { res in
+            // Get the files in user-selected folder when $openFile is true
+            do {
+                let folderURL = try res.get()
+                self.conductor.getPlayableFolderFiles(inFolderURL: folderURL)
+            } catch {
+                Log(error.localizedDescription, type: .error)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Example code as requested in #36. Uses `FileManager` to read from a user-selected folder and throws all of the audio files into a playlist. One thing to note is this required the entitlements file property `<key>com.apple.security.files.user-selected.read-write</key>` to be changed to `true` in order for the `FileManager` to work.