### PR TITLE
iOS Files in the Playlist can now be loaded

### DIFF
--- a/Cookbook/Cookbook/Recipes/Playlist.swift
+++ b/Cookbook/Cookbook/Recipes/Playlist.swift
@@ -53,12 +53,7 @@ class PlaylistConductor: ObservableObject {
     // Player functions
     func loadFile(url: URL) {
         do {
-            if url.startAccessingSecurityScopedResource() {
-                try player.load(url: url)
-                url.stopAccessingSecurityScopedResource()
-            } else {
-                Log("Could not load file", type: .error)
-            }
+            try player.load(url: url)
         } catch {
             Log(error.localizedDescription, type: .error)
         }


### PR DESCRIPTION
I tested the Playlist code I just made on iOS, and I needed to make a change in order to get the files to be found. I added `folderURL.startAccessingSecurityScopedResource()` and `folderURL.stopAccessingSecurityScopedResource()` in the appropriate places to allow the file URL's to be accessed outside of the app's container. I also got rid of the Uniform Type identifiers and just made an array containing all the file extensions the `AudioPlayer` supports.