### PR TITLE
Beefing up KeyboardView Part 2

### DIFF
--- a/Cookbook/Cookbook/Recipes/AmplitudeEnvelope.swift
+++ b/Cookbook/Cookbook/Recipes/AmplitudeEnvelope.swift
@@ -75,20 +75,68 @@ struct AmplitudeEnvelopeView: View {
             NodeOutputView(conductor.env)
             NodeRollingView(conductor.fader, color: .red)
             HStack {
-                Button(
-                action: {
-                    octaveCount -= 1
-                },
-                label: {
-                    Text("- Octave")
-                })
-                Button(
-                action: {
-                    octaveCount += 1
-                },
-                label: {
-                    Text("+ Octave")
-                })
+                VStack {
+                    Text("First Octave")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            firstOctave -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(firstOctave)")
+                        Button(
+                        action: {
+                            firstOctave += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Octave Count")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            octaveCount -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(octaveCount)")
+                        Button(
+                        action: {
+                            octaveCount += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Polyphonic Mode")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            polyphonicMode.toggle()
+                        },
+                        label: {
+                            Text("Toggle:")
+                        })
+                        if polyphonicMode {
+                            Text("ON")
+                        } else {
+                            Text("OFF")
+                        }
+                    }
+                }
             }
             KeyboardWidget(delegate: conductor,
                            firstOctave: firstOctave,

--- a/Cookbook/Cookbook/Recipes/DynamicOscillator.swift
+++ b/Cookbook/Cookbook/Recipes/DynamicOscillator.swift
@@ -99,20 +99,68 @@ struct DynamicOscillatorView: View {
                             range: 0...10).padding()
             NodeOutputView(conductor.osc)
             HStack {
-                Button(
-                action: {
-                    octaveCount -= 1
-                },
-                label: {
-                    Text("- Octave")
-                })
-                Button(
-                action: {
-                    octaveCount += 1
-                },
-                label: {
-                    Text("- Octave")
-                })
+                VStack {
+                    Text("First Octave")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            firstOctave -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(firstOctave)")
+                        Button(
+                        action: {
+                            firstOctave += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Octave Count")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            octaveCount -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(octaveCount)")
+                        Button(
+                        action: {
+                            octaveCount += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Polyphonic Mode")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            polyphonicMode.toggle()
+                        },
+                        label: {
+                            Text("Toggle:")
+                        })
+                        if polyphonicMode {
+                            Text("ON")
+                        } else {
+                            Text("OFF")
+                        }
+                    }
+                }
             }
             KeyboardWidget(delegate: conductor,
                            firstOctave: firstOctave,

--- a/Cookbook/Cookbook/Recipes/MorphingOscillator.swift
+++ b/Cookbook/Cookbook/Recipes/MorphingOscillator.swift
@@ -86,20 +86,68 @@ struct MorphingOscillatorView: View {
 
             NodeOutputView(conductor.osc)
             HStack {
-                Button(
-                action: {
-                    octaveCount -= 1
-                },
-                label: {
-                    Text("- Octave")
-                })
-                Button(
-                action: {
-                    octaveCount += 1
-                },
-                label: {
-                    Text("+ Octave")
-                })
+                VStack {
+                    Text("First Octave")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            firstOctave -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(firstOctave)")
+                        Button(
+                        action: {
+                            firstOctave += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Octave Count")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            octaveCount -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(octaveCount)")
+                        Button(
+                        action: {
+                            octaveCount += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Polyphonic Mode")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            polyphonicMode.toggle()
+                        },
+                        label: {
+                            Text("Toggle:")
+                        })
+                        if polyphonicMode {
+                            Text("ON")
+                        } else {
+                            Text("OFF")
+                        }
+                    }
+                }
             }
             KeyboardWidget(delegate: conductor,
                            firstOctave: firstOctave,

--- a/Cookbook/Cookbook/Recipes/Oscillator.swift
+++ b/Cookbook/Cookbook/Recipes/Oscillator.swift
@@ -80,20 +80,68 @@ struct OscillatorView: View {
                             range: 0...10).padding()
             NodeOutputView(conductor.osc)
             HStack {
-                Button(
-                action: {
-                    octaveCount -= 1
-                },
-                label: {
-                    Text("- Octave")
-                })
-                Button(
-                action: {
-                    octaveCount += 1
-                },
-                label: {
-                    Text("+ Octave")
-                })
+                VStack {
+                    Text("First Octave")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            firstOctave -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(firstOctave)")
+                        Button(
+                        action: {
+                            firstOctave += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Octave Count")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            octaveCount -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(octaveCount)")
+                        Button(
+                        action: {
+                            octaveCount += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Polyphonic Mode")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            polyphonicMode.toggle()
+                        },
+                        label: {
+                            Text("Toggle:")
+                        })
+                        if polyphonicMode {
+                            Text("ON")
+                        } else {
+                            Text("OFF")
+                        }
+                    }
+                }
             }
             KeyboardWidget(delegate: conductor,
                            firstOctave: firstOctave,

--- a/Cookbook/Cookbook/Recipes/PWMOscillator.swift
+++ b/Cookbook/Cookbook/Recipes/PWMOscillator.swift
@@ -88,20 +88,68 @@ struct PWMOscillatorView: View {
 
             NodeOutputView(conductor.osc)
             HStack {
-                Button(
-                action: {
-                    octaveCount -= 1
-                },
-                label: {
-                    Text("- Octave")
-                })
-                Button(
-                action: {
-                    octaveCount += 1
-                },
-                label: {
-                    Text("+ Octave")
-                })
+                VStack {
+                    Text("First Octave")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            firstOctave -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(firstOctave)")
+                        Button(
+                        action: {
+                            firstOctave += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Octave Count")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            octaveCount -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(octaveCount)")
+                        Button(
+                        action: {
+                            octaveCount += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Polyphonic Mode")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            polyphonicMode.toggle()
+                        },
+                        label: {
+                            Text("Toggle:")
+                        })
+                        if polyphonicMode {
+                            Text("ON")
+                        } else {
+                            Text("OFF")
+                        }
+                    }
+                }
             }
             KeyboardWidget(delegate: conductor,
                            firstOctave: firstOctave,

--- a/Cookbook/Cookbook/Recipes/PhaseDistortionOscillator.swift
+++ b/Cookbook/Cookbook/Recipes/PhaseDistortionOscillator.swift
@@ -91,20 +91,68 @@ struct PhaseDistortionOscillatorView: View {
 
             NodeOutputView(conductor.osc)
             HStack {
-                Button(
-                action: {
-                    octaveCount -= 1
-                },
-                label: {
-                    Text("- Octave")
-                })
-                Button(
-                action: {
-                    octaveCount += 1
-                },
-                label: {
-                    Text("+ Octave")
-                })
+                VStack {
+                    Text("First Octave")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            firstOctave -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(firstOctave)")
+                        Button(
+                        action: {
+                            firstOctave += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Octave Count")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            octaveCount -= 1
+                        },
+                        label: {
+                            Text("-")
+                        })
+                        Text("\(octaveCount)")
+                        Button(
+                        action: {
+                            octaveCount += 1
+                        },
+                        label: {
+                            Text("+")
+                        })
+                    }
+                }
+                .padding()
+                VStack {
+                    Text("Polyphonic Mode")
+                        .fontWeight(.bold)
+                    HStack {
+                        Button(
+                        action: {
+                            polyphonicMode.toggle()
+                        },
+                        label: {
+                            Text("Toggle:")
+                        })
+                        if polyphonicMode {
+                            Text("ON")
+                        } else {
+                            Text("OFF")
+                        }
+                    }
+                }
             }
             KeyboardWidget(delegate: conductor,
                            firstOctave: firstOctave,


### PR DESCRIPTION
This is part 2 of addressing #1. There are now buttons to control the `firstOctave` and toggle the `polyphonicMode` of each Cookbook example using the `KeyboardWidget`. However, the oscillators are not set up to receive polyphonic MIDI events yet. That's what I'm looking into next. But the `KeyboardView` does allow polyphonic events now once `polyphonicMode` is toggled on.