### PR TITLE
Added picker for devices, modified tuner sensitivity

### DIFF
--- a/Cookbook/Cookbook/Recipes/Tuner.swift
+++ b/Cookbook/Cookbook/Recipes/Tuner.swift
@@ -14,7 +14,7 @@ struct TunerData {
 
 class TunerConductor: ObservableObject {
     @Published var data = TunerData()
-    
+
     let engine = AudioEngine()
     let initialDevice: Device
 
@@ -50,7 +50,7 @@ class TunerConductor: ObservableObject {
             }
         }
     }
-    
+
     func update(_ pitch: AUValue, _ amp: AUValue) {
         // Reduces sensitivity to background noise to prevent random / fluctuating data.
         guard amp > 0.1 else { return }

--- a/Cookbook/Cookbook/Recipes/Tuner.swift
+++ b/Cookbook/Cookbook/Recipes/Tuner.swift
@@ -13,8 +13,6 @@ struct TunerData {
 }
 
 class TunerConductor: ObservableObject {
-    @Published var data = TunerData()
-
     let engine = AudioEngine()
     let initialDevice: Device
 
@@ -30,26 +28,7 @@ class TunerConductor: ObservableObject {
     let noteNamesWithSharps = ["C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"]
     let noteNamesWithFlats = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"]
 
-    init() {
-        guard let input = engine.input else { fatalError() }
-
-        guard let device = engine.inputDevice else { fatalError() }
-
-        initialDevice = device
-
-        mic = input
-        tappableNodeA = Fader(mic)
-        tappableNodeB = Fader(tappableNodeA)
-        tappableNodeC = Fader(tappableNodeB)
-        silence = Fader(tappableNodeC, gain: 0)
-        engine.output = silence
-
-        tracker = PitchTap(mic) { pitch, amp in
-            DispatchQueue.main.async {
-                self.update(pitch[0], amp[0])
-            }
-        }
-    }
+    @Published var data = TunerData()
 
     func update(_ pitch: AUValue, _ amp: AUValue) {
         // Reduces sensitivity to background noise to prevent random / fluctuating data.
@@ -79,6 +58,27 @@ class TunerConductor: ObservableObject {
         let octave = Int(log2f(pitch / frequency))
         data.noteNameWithSharps = "\(noteNamesWithSharps[index])\(octave)"
         data.noteNameWithFlats = "\(noteNamesWithFlats[index])\(octave)"
+    }
+
+    init() {
+        guard let input = engine.input else { fatalError() }
+
+        guard let device = engine.inputDevice else { fatalError() }
+
+        initialDevice = device
+
+        mic = input
+        tappableNodeA = Fader(mic)
+        tappableNodeB = Fader(tappableNodeA)
+        tappableNodeC = Fader(tappableNodeB)
+        silence = Fader(tappableNodeC, gain: 0)
+        engine.output = silence
+
+        tracker = PitchTap(mic) { pitch, amp in
+            DispatchQueue.main.async {
+                self.update(pitch[0], amp[0])
+            }
+        }
     }
 
     func start() {


### PR DESCRIPTION
Tuner sensitivity (line35)

Lines 17-23: 
I scrapped the nodes that were not being used.
'let initialDevice' is used by the new InputDevicePicker (to avoid messy optionality).
I changed the node vars to lets. Can't see why they need to be vars? (this could be due to my ignorance!)

Picker for devices (line 139):  
Changed the sheet to a picker. The picker feels more responsive as it updates instantly and does not need dismissing.