### PR TITLE
AmplitudeEnvelope - Gate closes in Polyphonic Mode

### DIFF
--- a/Cookbook/Cookbook.xcodeproj/project.pbxproj
+++ b/Cookbook/Cookbook.xcodeproj/project.pbxproj
@@ -1124,7 +1124,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/AudioKit/AudioKitUI";
 			requirement = {
-				branch = develop;
+				branch = main;
 				kind = branch;
 			};
 		};

--- a/Cookbook/Cookbook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cookbook/Cookbook.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -14,8 +14,8 @@
         "package": "AudioKitUI",
         "repositoryURL": "https://github.com/AudioKit/AudioKitUI",
         "state": {
-          "branch": "develop",
-          "revision": "202bd41abec56fcdc69e5b5342d99f36d975f63e",
+          "branch": "main",
+          "revision": "0c83572444e89ade02eef1809805a96a928c7678",
           "version": null
         }
       },


### PR DESCRIPTION
Hello,

In the Amplitude Envelope example from the Cookbook develop branch notes cut off when dragging between keys with Polyphonic Mode On.

I think the issue might be in calling closeGate() and openGate() back-to-back. This fix is hacky but seems to resolve the issue:

```
func noteOn(note: MIDINoteNumber) {
        if note != currentNote {
            env.closeGate()
            DispatchQueue.main.async
            { [self] in
                osc.frequency = note.midiNoteToFrequency()
                env.openGate()
            }
        }else{
            osc.frequency = note.midiNoteToFrequency()
            env.openGate()
        }
    }
```

(Only tested in the simulator)

Thanks,
Nick