### PR TITLE
Fix string interpolation.

### DIFF
--- a/Cookbook/Cookbook/Recipes/Drums.swift
+++ b/Cookbook/Cookbook/Recipes/Drums.swift
@@ -22,7 +22,7 @@ struct DrumSample {
         do {
             audioFile = try AVAudioFile(forReading: url)
         } catch {
-            Log("Could not load: $fileName")
+            Log("Could not load: \(fileName)")
         }
     }
 }


### PR DESCRIPTION
Use `\(fileName)` in the string.
