### PR TITLE
File path fix for MidiTrackDemo

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MIDITrack.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MIDITrack.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct MIDITrackDemo: View {
     @StateObject var viewModel = MIDITrackViewModel()
-    @State var fileURL: URL? = Bundle.main.url(forResource: "Demo", withExtension: "mid")!
+    @State var fileURL: URL? = Bundle.module.url(forResource: "MIDI Files/Demo", withExtension: "mid")!
     @State var isPlaying = false
     public var body: some View {
         VStack {
@@ -39,7 +39,7 @@ struct MIDITrackDemo: View {
         })
         .onAppear(perform: {
             viewModel.startEngine()
-            viewModel.loadSequencerFile(fileURL: Bundle.main.url(forResource: "Demo", withExtension: "mid")!)
+            viewModel.loadSequencerFile(fileURL: Bundle.module.url(forResource: "MIDI Files/Demo", withExtension: "mid")!)
         })
         .onDisappear(perform: {
             viewModel.stop()


### PR DESCRIPTION
The midi file moved locations in the latest update creating a crash. It might be nice to make the URL address optional in the future. 