### PR TITLE
Update Parameter Control

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/BitCrusher.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/BitCrusher.swift
@@ -28,7 +28,7 @@ struct BitCrusherView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.bitcrusher.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/BitCrusher.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/BitCrusher.swift
@@ -28,11 +28,11 @@ struct BitCrusherView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.bitcrusher.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.bitcrusher,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Clipper.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Clipper.swift
@@ -31,11 +31,11 @@ struct ClipperView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.clipper.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.clipper,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Clipper.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Clipper.swift
@@ -31,7 +31,7 @@ struct ClipperView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.clipper.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Decimator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Decimator.swift
@@ -33,7 +33,7 @@ struct DecimatorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.decimator.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Decimator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/Decimator.swift
@@ -33,11 +33,11 @@ struct DecimatorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.decimator.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.decimator,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/RingModulator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/RingModulator.swift
@@ -28,11 +28,11 @@ struct RingModulatorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.ringModulator.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.ringModulator,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/RingModulator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/RingModulator.swift
@@ -28,7 +28,7 @@ struct RingModulatorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.ringModulator.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/TanhDistortion.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/TanhDistortion.swift
@@ -28,7 +28,7 @@ struct TanhDistortionView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.distortion.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/TanhDistortion.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Distortion/TanhDistortion.swift
@@ -28,11 +28,11 @@ struct TanhDistortionView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.distortion.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.distortion,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoPanner.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoPanner.swift
@@ -28,7 +28,7 @@ struct AutoPannerView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.panner.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoPanner.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoPanner.swift
@@ -28,11 +28,11 @@ struct AutoPannerView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.panner.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.panner,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoWah.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoWah.swift
@@ -29,7 +29,7 @@ struct AutoWahView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.autowah.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoWah.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/AutoWah.swift
@@ -29,11 +29,11 @@ struct AutoWahView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.autowah.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.autowah,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Balancer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Balancer.swift
@@ -54,8 +54,8 @@ struct BalancerView: View {
         VStack {
             PlayerControls(conductor: conductor)
             HStack {
-                CookbookKnob(text:"Rate", parameter: $conductor.rate, range: 0.3125 ... 5)
-                CookbookKnob(text:"Frequency", parameter: $conductor.frequency, range: 220 ... 880)
+                CookbookKnob(text: "Rate", parameter: $conductor.rate, range: 0.3125 ... 5)
+                CookbookKnob(text: "Frequency", parameter: $conductor.frequency, range: 220 ... 880)
                 ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Balancer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Balancer.swift
@@ -54,15 +54,9 @@ struct BalancerView: View {
         VStack {
             PlayerControls(conductor: conductor)
             HStack {
-                VStack {
-                    Text("Rate")
-                    SmallKnob(value: $conductor.rate, range: 0.3125 ... 5)
-                }
-                VStack {
-                    Text("Frequency")
-                    SmallKnob(value: $conductor.frequency, range: 220 ... 880)
-                }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                CookbookKnob(text:"Rate", parameter: $conductor.rate, range: 0.3125 ... 5)
+                CookbookKnob(text:"Frequency", parameter: $conductor.frequency, range: 220 ... 880)
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.balancer,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Chorus.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Chorus.swift
@@ -29,7 +29,7 @@ struct ChorusView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.chorus.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Chorus.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Chorus.swift
@@ -29,11 +29,11 @@ struct ChorusView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.chorus.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.chorus,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Compressor.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Compressor.swift
@@ -29,7 +29,7 @@ struct CompressorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.compressor.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Compressor.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Compressor.swift
@@ -29,11 +29,11 @@ struct CompressorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.compressor.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player, wet: conductor.compressor, mix: conductor.dryWetMixer)
         }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Convolution.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Convolution.swift
@@ -58,12 +58,12 @@ struct ConvolutionView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
-                ParameterSlider(text: "Dry Audio to Convolved",
+            HStack() {
+                CookbookKnob(text: "Dry Audio to Convolved",
                                 parameter: $conductor.data.dryWetMix,
                                 range: 0 ... 1,
                                 units: "%")
-                ParameterSlider(text: "Stairwell to Dish",
+                CookbookKnob(text: "Stairwell to Dish",
                                 parameter: $conductor.data.stairwellDishMix,
                                 range: 0 ... 1,
                                 units: "%")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Convolution.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Convolution.swift
@@ -58,7 +58,7 @@ struct ConvolutionView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 CookbookKnob(text: "Dry Audio to Convolved",
                                 parameter: $conductor.data.dryWetMix,
                                 range: 0 ... 1,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Delay.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Delay.swift
@@ -40,11 +40,11 @@ struct DelayView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.delay.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.delay,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Delay.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Delay.swift
@@ -40,7 +40,7 @@ struct DelayView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.delay.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/DynamicRangeCompressor.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/DynamicRangeCompressor.swift
@@ -28,11 +28,11 @@ struct DynamicRangeCompressorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.compressor.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.compressor,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/DynamicRangeCompressor.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/DynamicRangeCompressor.swift
@@ -28,7 +28,7 @@ struct DynamicRangeCompressorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.compressor.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Expander.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Expander.swift
@@ -29,7 +29,7 @@ struct ExpanderView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.expander.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Expander.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Expander.swift
@@ -29,11 +29,11 @@ struct ExpanderView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.expander.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.expander,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Flanger.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Flanger.swift
@@ -29,7 +29,7 @@ struct FlangerView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.flanger.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Flanger.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Flanger.swift
@@ -29,11 +29,11 @@ struct FlangerView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.flanger.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.flanger,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Panner.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Panner.swift
@@ -28,7 +28,7 @@ struct PannerView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.panner.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Panner.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Panner.swift
@@ -28,11 +28,11 @@ struct PannerView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.panner.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.panner,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PeakLimiter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PeakLimiter.swift
@@ -33,7 +33,7 @@ struct PeakLimiterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.peakLimiter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PeakLimiter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PeakLimiter.swift
@@ -33,11 +33,11 @@ struct PeakLimiterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.peakLimiter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.peakLimiter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Phaser.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Phaser.swift
@@ -28,11 +28,11 @@ struct PhaserView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.phaser.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.phaser,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Phaser.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Phaser.swift
@@ -28,7 +28,7 @@ struct PhaserView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.phaser.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PitchShifter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PitchShifter.swift
@@ -28,11 +28,11 @@ struct PitchShifterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.pitchshifter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.pitchshifter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PitchShifter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PitchShifter.swift
@@ -28,7 +28,7 @@ struct PitchShifterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.pitchshifter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PlaybackSpeed.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/PlaybackSpeed.swift
@@ -33,7 +33,7 @@ struct PlaybackSpeedView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            ParameterSlider(text: "Rate",
+            CookbookKnob(text: "Rate",
                             parameter: $conductor.rate,
                             range: 0.3125 ... 5,
                             units: "Generic")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/StringResonator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/StringResonator.swift
@@ -28,7 +28,7 @@ struct StringResonatorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/StringResonator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/StringResonator.swift
@@ -28,11 +28,11 @@ struct StringResonatorView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TimePitch.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TimePitch.swift
@@ -44,12 +44,12 @@ struct TimePitchView: View {
         VStack {
             PlayerControls(conductor: conductor)
 
-            HStack(spacing: 50) {
-                ParameterSlider(text: "Rate",
+            HStack() {
+                CookbookKnob(text: "Rate",
                                 parameter: self.$conductor.data.rate,
                                 range: 0.3125 ... 5,
                                 units: "Generic")
-                ParameterSlider(text: "Pitch",
+                CookbookKnob(text: "Pitch",
                                 parameter: self.$conductor.data.pitch,
                                 range: -2400 ... 2400,
                                 units: "Cents")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TimePitch.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TimePitch.swift
@@ -44,7 +44,7 @@ struct TimePitchView: View {
         VStack {
             PlayerControls(conductor: conductor)
 
-            HStack() {
+            HStack {
                 CookbookKnob(text: "Rate",
                                 parameter: self.$conductor.data.rate,
                                 range: 0.3125 ... 5,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TransientShaper.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TransientShaper.swift
@@ -29,7 +29,7 @@ struct TransientShaperView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.transientshaper.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TransientShaper.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/TransientShaper.swift
@@ -29,11 +29,11 @@ struct TransientShaperView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.transientshaper.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.transientshaper,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Tremolo.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Tremolo.swift
@@ -28,7 +28,7 @@ struct TremoloView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.tremolo.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Tremolo.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/Tremolo.swift
@@ -28,11 +28,11 @@ struct TremoloView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.tremolo.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.tremolo,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/VariableDelay.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/VariableDelay.swift
@@ -28,11 +28,11 @@ struct VariableDelayView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.delay.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.delay,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/VariableDelay.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Effects/VariableDelay.swift
@@ -28,7 +28,7 @@ struct VariableDelayView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.delay.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandPassButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandPassButterworthFilter.swift
@@ -34,11 +34,11 @@ struct BandPassButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandPassButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandPassButterworthFilter.swift
@@ -34,7 +34,7 @@ struct BandPassButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandRejectButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandRejectButterworthFilter.swift
@@ -28,11 +28,11 @@ struct BandRejectButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandRejectButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/BandRejectButterworthFilter.swift
@@ -28,7 +28,7 @@ struct BandRejectButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/CombFilterReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/CombFilterReverb.swift
@@ -28,11 +28,11 @@ struct CombFilterReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/CombFilterReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/CombFilterReverb.swift
@@ -28,7 +28,7 @@ struct CombFilterReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/EqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/EqualizerFilter.swift
@@ -28,11 +28,11 @@ struct EqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/EqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/EqualizerFilter.swift
@@ -28,7 +28,7 @@ struct EqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/FormantFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/FormantFilter.swift
@@ -28,7 +28,7 @@ struct FormantFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/FormantFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/FormantFilter.swift
@@ -28,11 +28,11 @@ struct FormantFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassButterworthFilter.swift
@@ -32,11 +32,11 @@ struct HighPassButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassButterworthFilter.swift
@@ -32,7 +32,7 @@ struct HighPassButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassFilter.swift
@@ -28,7 +28,7 @@ struct HighPassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighPassFilter.swift
@@ -28,11 +28,11 @@ struct HighPassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfFilter.swift
@@ -28,7 +28,7 @@ struct HighShelfFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfFilter.swift
@@ -28,11 +28,11 @@ struct HighShelfFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfParametricEqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfParametricEqualizerFilter.swift
@@ -28,11 +28,11 @@ struct HighShelfParametricEqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.equalizer.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.equalizer,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfParametricEqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/HighShelfParametricEqualizerFilter.swift
@@ -28,7 +28,7 @@ struct HighShelfParametricEqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.equalizer.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/KorgLowPassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/KorgLowPassFilter.swift
@@ -28,11 +28,11 @@ struct KorgLowPassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/KorgLowPassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/KorgLowPassFilter.swift
@@ -28,7 +28,7 @@ struct KorgLowPassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassButterworthFilter.swift
@@ -32,11 +32,11 @@ struct LowPassButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassButterworthFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassButterworthFilter.swift
@@ -32,7 +32,7 @@ struct LowPassButterworthFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassFilter.swift
@@ -28,7 +28,7 @@ struct LowPassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowPassFilter.swift
@@ -28,11 +28,11 @@ struct LowPassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfFilter.swift
@@ -28,11 +28,11 @@ struct LowShelfFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfFilter.swift
@@ -28,7 +28,7 @@ struct LowShelfFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfParametricEqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfParametricEqualizerFilter.swift
@@ -28,7 +28,7 @@ struct LowShelfParametricEqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfParametricEqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/LowShelfParametricEqualizerFilter.swift
@@ -28,11 +28,11 @@ struct LowShelfParametricEqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ModalResonanceFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ModalResonanceFilter.swift
@@ -28,11 +28,11 @@ struct ModalResonanceFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ModalResonanceFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ModalResonanceFilter.swift
@@ -28,7 +28,7 @@ struct ModalResonanceFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/MoogLadder.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/MoogLadder.swift
@@ -38,7 +38,7 @@ struct MoogLadderView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/MoogLadder.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/MoogLadder.swift
@@ -38,11 +38,11 @@ struct MoogLadderView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/PeakingParametricEqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/PeakingParametricEqualizerFilter.swift
@@ -28,11 +28,11 @@ struct PeakingParametricEqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/PeakingParametricEqualizerFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/PeakingParametricEqualizerFilter.swift
@@ -28,7 +28,7 @@ struct PeakingParametricEqualizerFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ResonantFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ResonantFilter.swift
@@ -28,11 +28,11 @@ struct ResonantFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ResonantFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ResonantFilter.swift
@@ -28,7 +28,7 @@ struct ResonantFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/RolandTB303Filter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/RolandTB303Filter.swift
@@ -28,11 +28,11 @@ struct RolandTB303FilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/RolandTB303Filter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/RolandTB303Filter.swift
@@ -28,7 +28,7 @@ struct RolandTB303FilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ThreePoleLowpassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ThreePoleLowpassFilter.swift
@@ -28,11 +28,11 @@ struct ThreePoleLowpassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ThreePoleLowpassFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ThreePoleLowpassFilter.swift
@@ -28,7 +28,7 @@ struct ThreePoleLowpassFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneComplementFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneComplementFilter.swift
@@ -28,11 +28,11 @@ struct ToneComplementFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneComplementFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneComplementFilter.swift
@@ -28,7 +28,7 @@ struct ToneComplementFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneFilter.swift
@@ -28,7 +28,7 @@ struct ToneFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.filter.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneFilter.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Filters/ToneFilter.swift
@@ -28,11 +28,11 @@ struct ToneFilterView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.filter.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.filter,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
@@ -103,9 +103,9 @@ struct DrumSequencerView: View {
             Text("Randomize Hi-hats").onTapGesture {
                 conductor.randomize()
             }
-            ParameterSlider(text: "Tempo",
+            CookbookKnob(text: "Tempo",
                             parameter: $conductor.tempo,
-                            range: 60 ... 300).padding(5).frame(height: 100)
+                            range: 60 ... 300).padding(5)
             NodeOutputView(conductor.drums)
             Spacer()
         }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/GraphicEqualizer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/GraphicEqualizer.swift
@@ -69,24 +69,26 @@ struct GraphicEqualizerView: View {
 
     var body: some View {
         VStack {
-            ParameterSlider(text: "Band 1",
-                            parameter: $conductor.data.gain1,
-                            range: 0 ... 2).padding()
-            ParameterSlider(text: "Band 2",
-                            parameter: $conductor.data.gain2,
-                            range: 0 ... 2).padding()
-            ParameterSlider(text: "Band 3",
-                            parameter: $conductor.data.gain3,
-                            range: 0 ... 2).padding()
-            ParameterSlider(text: "Band 4",
-                            parameter: $conductor.data.gain4,
-                            range: 0 ... 2).padding()
-            ParameterSlider(text: "Band 5",
-                            parameter: $conductor.data.gain5,
-                            range: 0 ... 2).padding()
-            ParameterSlider(text: "Band 6",
-                            parameter: $conductor.data.gain6,
-                            range: 0 ... 2).padding()
+            HStack{
+                CookbookKnob(text: "Band 1",
+                                parameter: $conductor.data.gain1,
+                                range: 0 ... 2)
+                CookbookKnob(text: "Band 2",
+                                parameter: $conductor.data.gain2,
+                                range: 0 ... 2)
+                CookbookKnob(text: "Band 3",
+                                parameter: $conductor.data.gain3,
+                                range: 0 ... 2)
+                CookbookKnob(text: "Band 4",
+                                parameter: $conductor.data.gain4,
+                                range: 0 ... 2)
+                CookbookKnob(text: "Band 5",
+                                parameter: $conductor.data.gain5,
+                                range: 0 ... 2)
+                CookbookKnob(text: "Band 6",
+                                parameter: $conductor.data.gain6,
+                                range: 0 ... 2)
+            }.padding(5)
             FFTView(conductor.fader)
         }.cookbookNavBarTitle("Graphic Equalizer")
             .onAppear {

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/GraphicEqualizer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/GraphicEqualizer.swift
@@ -69,7 +69,7 @@ struct GraphicEqualizerView: View {
 
     var body: some View {
         VStack {
-            HStack{
+            HStack {
                 CookbookKnob(text: "Band 1",
                                 parameter: $conductor.data.gain1,
                                 range: 0 ... 2)

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/InstrumentEXS.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/InstrumentEXS.swift
@@ -41,6 +41,7 @@ class InstrumentEXSConductor: ObservableObject, HasAudioEngine {
 
 struct InstrumentEXSView: View {
     @StateObject var conductor = InstrumentEXSConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         Keyboard(layout: .piano(pitchRange: Pitch(48) ... Pitch(64)),
@@ -52,5 +53,7 @@ struct InstrumentEXSView: View {
             .onDisappear {
                 conductor.stop()
             }
+            .background(colorScheme == .dark ?
+                         Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/MusicToy.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/MusicToy.swift
@@ -185,7 +185,7 @@ class MusicToyConductor: ObservableObject, HasAudioEngine {
 
 struct MusicToyView: View {
     @StateObject var conductor = MusicToyConductor()
-
+    
     var body: some View {
         VStack {
             HStack(spacing: 20) {
@@ -207,54 +207,51 @@ struct MusicToyView: View {
                     Text("16").tag(16)
                 }.pickerStyle(SegmentedPickerStyle())
             }
-            ParameterSlider(text: "Tempo",
-                            parameter: $conductor.data.tempo,
-                            range: 20 ... 300).padding(5)
-            ParameterSlider(text: "Drums Volume",
-                            parameter: $conductor.data.drumVolume,
-                            range: 0.5 ... 1).padding(5)
-            VStack {
-                HStack {
-                    Text("Arpeggio")
-                    Picker("Arpeggio", selection: $conductor.data.arpeggioSound) {
-                        Text("Square").tag(Sound.square)
-                        Text("Saw").tag(Sound.saw)
-                        Text("Noise").tag(Sound.noisy)
-                    }.pickerStyle(SegmentedPickerStyle())
-                }
-                ParameterSlider(text: "Arpeggio Volume",
-                                parameter: $conductor.data.arpeggioVolume,
-                                range: 0.5 ... 1).padding(5)
+            HStack {
+                CookbookKnob(text: "Tempo",
+                             parameter: $conductor.data.tempo,
+                             range: 20 ... 300).padding(5)
+                CookbookKnob(text: "Filter Frequency",
+                             parameter: $conductor.data.filterFrequency,
+                             range: 0 ... 1).padding(5)
             }
-            VStack {
-                HStack {
-                    Text("Chords")
-                    Picker("Chords", selection: $conductor.data.padSound) {
-                        Text("Square").tag(Sound.square)
-                        Text("Saw").tag(Sound.saw)
-                        Text("Pad").tag(Sound.pad)
-                    }.pickerStyle(SegmentedPickerStyle())
-                }
-                ParameterSlider(text: "Chords Volume",
-                                parameter: $conductor.data.padVolume,
-                                range: 0.5 ... 1).padding(5)
+            HStack {
+                Text("Arpeggio")
+                Picker("Arpeggio", selection: $conductor.data.arpeggioSound) {
+                    Text("Square").tag(Sound.square)
+                    Text("Saw").tag(Sound.saw)
+                    Text("Noise").tag(Sound.noisy)
+                }.pickerStyle(SegmentedPickerStyle())
             }
-
-            VStack {
-                HStack {
-                    Text("Bass")
-                    Picker("Bass", selection: $conductor.data.bassSound) {
-                        Text("Square").tag(Sound.square)
-                        Text("Saw").tag(Sound.saw)
-                    }.pickerStyle(SegmentedPickerStyle())
-                }
-                ParameterSlider(text: "Bass Volume",
-                                parameter: $conductor.data.bassVolume,
-                                range: 0.5 ... 1).padding(5)
+            HStack {
+                Text("Chords")
+                Picker("Chords", selection: $conductor.data.padSound) {
+                    Text("Square").tag(Sound.square)
+                    Text("Saw").tag(Sound.saw)
+                    Text("Pad").tag(Sound.pad)
+                }.pickerStyle(SegmentedPickerStyle())
             }
-            ParameterSlider(text: "Filter Frequency",
-                            parameter: $conductor.data.filterFrequency,
-                            range: 0 ... 1).padding(5)
+            HStack {
+                Text("Bass")
+                Picker("Bass", selection: $conductor.data.bassSound) {
+                    Text("Square").tag(Sound.square)
+                    Text("Saw").tag(Sound.saw)
+                }.pickerStyle(SegmentedPickerStyle())
+            }
+            HStack {
+                CookbookKnob(text: "Drums Volume",
+                             parameter: $conductor.data.drumVolume,
+                             range: 0.5 ... 1).padding(5)
+                CookbookKnob(text: "Arpeggio Volume",
+                             parameter: $conductor.data.arpeggioVolume,
+                             range: 0.5 ... 1).padding(5)
+                CookbookKnob(text: "Chords Volume",
+                             parameter: $conductor.data.padVolume,
+                             range: 0.5 ... 1).padding(5)
+                CookbookKnob(text: "Bass Volume",
+                             parameter: $conductor.data.bassVolume,
+                             range: 0.5 ... 1).padding(5)
+            }
         }
         .padding()
         .cookbookNavBarTitle("Music Toy")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/MusicToy.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/MusicToy.swift
@@ -185,7 +185,7 @@ class MusicToyConductor: ObservableObject, HasAudioEngine {
 
 struct MusicToyView: View {
     @StateObject var conductor = MusicToyConductor()
-    
+
     var body: some View {
         VStack {
             HStack(spacing: 20) {

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/NoiseGenerators.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/NoiseGenerators.swift
@@ -49,19 +49,10 @@ struct NoiseGeneratorsView: View {
     var body: some View {
         VStack {
             HStack {
-                VStack(alignment: .center) {
-                    Text("Brownian").font(.title2)
-                    SmallKnob(value: self.$conductor.data.brownianAmplitude)
-                }
-                VStack(alignment: .center) {
-                    Text("Pink").font(.title2)
-                    SmallKnob(value: self.$conductor.data.pinkAmplitude)
-                }
-                VStack(alignment: .center) {
-                    Text("White").font(.title2)
-                    SmallKnob(value: self.$conductor.data.whiteAmplitude)
-                }
-            }
+                CookbookKnob(text: "Brownian", parameter: self.$conductor.data.brownianAmplitude, range: 0...1)
+                CookbookKnob(text: "Pink", parameter: self.$conductor.data.pinkAmplitude, range: 0...1)
+                CookbookKnob(text: "White", parameter: self.$conductor.data.whiteAmplitude, range: 0...1)
+            }.padding(5)
             NodeOutputView(conductor.mixer)
         }.cookbookNavBarTitle("Noise Generators")
             .onAppear {

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/VocalTract.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/VocalTract.swift
@@ -52,9 +52,9 @@ struct VocalTractView: View {
 
             HStack {
                 ForEach(conductor.voc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-            }
+            }.frame(height: 150)
             NodeOutputView(conductor.voc)
         }.cookbookNavBarTitle("Vocal Tract")
             .padding()

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/PitchShfitOperation.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/PitchShfitOperation.swift
@@ -55,19 +55,19 @@ struct PitchShiftOperationView: View {
         VStack {
             PlayerControls(conductor: conductor)
             HStack {
-                ParameterSlider(text: "Base Shift",
+                CookbookKnob(text: "Base Shift",
                                 parameter: $conductor.data.baseShift,
                                 range: -12 ... 12,
                                 units: "Semitones")
-                ParameterSlider(text: "Range",
+                CookbookKnob(text: "Range",
                                 parameter: $conductor.data.range,
                                 range: 0 ... 24,
                                 units: "Semitones")
-                ParameterSlider(text: "Speed",
+                CookbookKnob(text: "Speed",
                                 parameter: $conductor.data.speed,
                                 range: 0.001 ... 10,
                                 units: "Hz")
-                ParameterSlider(text: "Mix",
+                CookbookKnob(text: "Mix",
                                 parameter: $conductor.data.balance,
                                 range: 0 ... 1,
                                 units: "%")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/SmoothDelayOperation.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/SmoothDelayOperation.swift
@@ -50,12 +50,12 @@ struct SmoothDelayOperationView: View {
     var body: some View {
         VStack(spacing: 20) {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
-                ParameterSlider(text: "Time",
+            HStack() {
+                CookbookKnob(text: "Time",
                                 parameter: $conductor.data.time,
                                 range: 0 ... 0.3,
                                 units: "Seconds")
-                ParameterSlider(text: "Feedback",
+                CookbookKnob(text: "Feedback",
                                 parameter: $conductor.data.feedback,
                                 range: 0 ... 1,
                                 units: "%")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/SmoothDelayOperation.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/SmoothDelayOperation.swift
@@ -50,7 +50,7 @@ struct SmoothDelayOperationView: View {
     var body: some View {
         VStack(spacing: 20) {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 CookbookKnob(text: "Time",
                                 parameter: $conductor.data.time,
                                 range: 0 ... 0.3,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/StereoDelayOperation.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/StereoDelayOperation.swift
@@ -52,19 +52,21 @@ struct StereoDelayOperationView: View {
         VStack {
             PlayerControls(conductor: conductor)
             HStack(spacing: 20) {
-                ParameterSlider(text: "Left Time",
+                CookbookKnob(text: "Left Time",
                                 parameter: self.$conductor.data.leftTime,
                                 range: 0 ... 0.3,
                                 units: "Seconds")
-                ParameterSlider(text: "Left Feedback",
+                CookbookKnob(text: "Left Feedback",
                                 parameter: self.$conductor.data.leftFeedback,
                                 range: 0 ... 1,
                                 units: "%")
-                ParameterSlider(text: "Right Time",
+            }
+            HStack(spacing: 20) {
+                CookbookKnob(text: "Right Time",
                                 parameter: self.$conductor.data.rightTime,
                                 range: 0 ... 0.3,
                                 units: "Seconds")
-                ParameterSlider(text: "Right Feedback",
+                CookbookKnob(text: "Right Feedback",
                                 parameter: self.$conductor.data.rightFeedback,
                                 range: 0 ... 1,
                                 units: "%")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/VariableDelayOperation.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Operations/VariableDelayOperation.swift
@@ -59,19 +59,19 @@ struct VariableDelayOperationView: View {
         VStack {
             PlayerControls(conductor: conductor)
             HStack(spacing: 20) {
-                ParameterSlider(text: "Max Time",
+                CookbookKnob(text: "Max Time",
                                 parameter: self.$conductor.data.maxTime,
                                 range: 0 ... 0.3,
                                 units: "Seconds")
-                ParameterSlider(text: "Frequency",
+                CookbookKnob(text: "Frequency",
                                 parameter: self.$conductor.data.frequency,
                                 range: 0 ... 1,
                                 units: "Hz")
-                ParameterSlider(text: "Feedback Frequency",
+                CookbookKnob(text: "Feedback Frequency",
                                 parameter: self.$conductor.data.feedbackFrequency,
                                 range: 0 ... 1,
                                 units: "Hz")
-                ParameterSlider(text: "Mix",
+                CookbookKnob(text: "Mix",
                                 parameter: self.$conductor.data.balance,
                                 range: 0 ... 1,
                                 units: "%")

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/AmplitudeEnvelope.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/AmplitudeEnvelope.swift
@@ -44,10 +44,25 @@ class AmplitudeEnvelopeConductor: ObservableObject, HasAudioEngine {
         osc.amplitude = 1
         engine.output = fader
     }
+
+    func start() {
+        osc.start()
+        do {
+            try engine.start()
+        } catch let err {
+            Log(err)
+        }
+    }
+
+    func stop() {
+        osc.stop()
+        engine.stop()
+    }
 }
 
 struct AmplitudeEnvelopeView: View {
     @StateObject var conductor = AmplitudeEnvelopeConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack {
@@ -70,5 +85,7 @@ struct AmplitudeEnvelopeView: View {
         .onDisappear {
             conductor.stop()
         }
+        .background(colorScheme == .dark ?
+                     Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/DynamicOscillator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/DynamicOscillator.swift
@@ -32,6 +32,7 @@ class DynamicOscillatorConductor: ObservableObject, HasAudioEngine {
 
 struct DynamicOscillatorView: View {
     @StateObject var conductor = DynamicOscillatorConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack {
@@ -61,7 +62,7 @@ struct DynamicOscillatorView: View {
             Spacer()
             HStack {
                 ForEach(conductor.osc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
             }
             NodeOutputView(conductor.osc)
@@ -76,5 +77,7 @@ struct DynamicOscillatorView: View {
             .onDisappear {
                 conductor.stop()
             }
+            .background(colorScheme == .dark ?
+                         Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/FMOscillator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/FMOscillator.swift
@@ -51,7 +51,7 @@ struct FMOscillatorView: View {
             }.padding()
             HStack {
                 ForEach(conductor.osc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
             }
             NodeOutputView(conductor.osc)

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/MorphingOscillator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/MorphingOscillator.swift
@@ -32,6 +32,7 @@ class MorphingOscillatorConductor: ObservableObject, HasAudioEngine {
 
 struct MorphingOscillatorView: View {
     @StateObject var conductor = MorphingOscillatorConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack {
@@ -40,7 +41,7 @@ struct MorphingOscillatorView: View {
             }
             HStack {
                 ForEach(conductor.osc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
             }
 
@@ -57,5 +58,7 @@ struct MorphingOscillatorView: View {
         .onDisappear {
             conductor.stop()
         }
+        .background(colorScheme == .dark ?
+                     Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/Oscillator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/Oscillator.swift
@@ -32,6 +32,7 @@ class OscillatorConductor: ObservableObject, HasAudioEngine {
 
 struct OscillatorView: View {
     @StateObject var conductor = OscillatorConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack {
@@ -40,7 +41,7 @@ struct OscillatorView: View {
             }
             HStack {
                 ForEach(conductor.osc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
             }
             NodeOutputView(conductor.osc)
@@ -55,5 +56,7 @@ struct OscillatorView: View {
             .onDisappear {
                 conductor.stop()
             }
+            .background(colorScheme == .dark ?
+                         Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/PWMOscillator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/PWMOscillator.swift
@@ -32,6 +32,7 @@ class PWMOscillatorConductor: ObservableObject, HasAudioEngine {
 
 struct PWMOscillatorView: View {
     @StateObject var conductor = PWMOscillatorConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack {
@@ -41,9 +42,9 @@ struct PWMOscillatorView: View {
             Spacer()
             HStack {
                 ForEach(conductor.osc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-            }
+            }.padding(5)
             NodeOutputView(conductor.osc)
             Keyboard(layout: .piano(pitchRange: Pitch(48) ... Pitch(64)),
                      noteOn: conductor.noteOn,
@@ -56,5 +57,7 @@ struct PWMOscillatorView: View {
             .onDisappear {
                 conductor.stop()
             }
+            .background(colorScheme == .dark ?
+                         Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/PhaseDistortionOscillator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Oscillators/PhaseDistortionOscillator.swift
@@ -32,6 +32,7 @@ class PhaseDistortionOscillatorConductor: ObservableObject, HasAudioEngine {
 
 struct PhaseDistortionOscillatorView: View {
     @StateObject var conductor = PhaseDistortionOscillatorConductor()
+    @Environment(\.colorScheme) var colorScheme
 
     var body: some View {
         VStack {
@@ -40,7 +41,7 @@ struct PhaseDistortionOscillatorView: View {
             }
             HStack {
                 ForEach(conductor.osc.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
             }
 
@@ -56,5 +57,7 @@ struct PhaseDistortionOscillatorView: View {
             .onDisappear {
                 conductor.stop()
             }
+            .background(colorScheme == .dark ?
+                         Color.clear : Color(red: 0.9, green: 0.9, blue: 0.9))
     }
 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/ChowningReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/ChowningReverb.swift
@@ -28,7 +28,7 @@ struct ChowningReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+            ParameterRow(param: conductor.dryWetMixer.parameters[0])
             DryWetMixView(dry: conductor.player,
                           wet: conductor.reverb,
                           mix: conductor.dryWetMixer)

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/CostelloReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/CostelloReverb.swift
@@ -28,7 +28,7 @@ struct CostelloReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.reverb.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/CostelloReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/CostelloReverb.swift
@@ -28,11 +28,11 @@ struct CostelloReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.reverb.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.reverb,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/FlatFrequencyResponseReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/FlatFrequencyResponseReverb.swift
@@ -28,11 +28,11 @@ struct FlatFrequencyResponseReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(conductor.reverb.parameters) {
-                    ParameterEditor2(param: $0)
+                    ParameterRow(param: $0)
                 }
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.reverb,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/FlatFrequencyResponseReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/FlatFrequencyResponseReverb.swift
@@ -28,7 +28,7 @@ struct FlatFrequencyResponseReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(conductor.reverb.parameters) {
                     ParameterRow(param: $0)
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/ZitaReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/ZitaReverb.swift
@@ -32,12 +32,12 @@ struct ZitaReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack() {
+            HStack {
                 ForEach(0..<6) {
                     ParameterRow(param: conductor.reverb.parameters[$0])
                 }
             }
-            HStack() {
+            HStack {
                 ForEach(6..<10) {
                     ParameterRow(param: conductor.reverb.parameters[$0])
                 }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/ZitaReverb.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/Reverbs/ZitaReverb.swift
@@ -32,17 +32,16 @@ struct ZitaReverbView: View {
     var body: some View {
         VStack {
             PlayerControls(conductor: conductor)
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(0..<6) {
-                    ParameterEditor2(param: conductor.reverb.parameters[$0])
+                    ParameterRow(param: conductor.reverb.parameters[$0])
                 }
             }
-            HStack(spacing: 50) {
+            HStack() {
                 ForEach(6..<10) {
-                    ParameterEditor2(param: conductor.reverb.parameters[$0])
+                    ParameterRow(param: conductor.reverb.parameters[$0])
                 }
-
-                ParameterEditor2(param: conductor.dryWetMixer.parameters[0])
+                ParameterRow(param: conductor.dryWetMixer.parameters[0])
             }
             DryWetMixView(dry: conductor.player,
                           wet: conductor.reverb,

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Reusable Components/CookbookKnob.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Reusable Components/CookbookKnob.swift
@@ -40,9 +40,6 @@ public struct CookbookKnob: View {
                     .lineLimit(1)
             }
             SmallKnob(value: $parameter, range: range)
-            
         }.frame(maxWidth: 150, maxHeight: 200).frame(minHeight: 100)
     }
 }
-
-

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Reusable Components/CookbookKnob.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Reusable Components/CookbookKnob.swift
@@ -1,0 +1,48 @@
+import AVFoundation
+import Controls
+import SwiftUI
+
+public struct CookbookKnob: View {
+    var text: String
+    @Binding var parameter: AUValue
+    var range: ClosedRange<AUValue>
+    var format: String = "%0.2f"
+    var units: String = ""
+
+    public init(text: String,
+                parameter: Binding<Float>,
+                range: ClosedRange<AUValue>,
+                units: String = "") {
+        _parameter = parameter
+        self.text = text
+        self.range = range
+        self.units = units
+    }
+
+    public var body: some View {
+        VStack {
+            Text(text)
+                .lineLimit(1)
+            if units == "" || units == "Generic" {
+                Text("\(parameter, specifier: format)")
+                    .lineLimit(1)
+            } else if units == "%" || units == "Percent" {
+                Text("\(parameter * 100, specifier: "%0.f")%")
+                    .lineLimit(1)
+            } else if units == "Percent-0-100" { // for audio units that use 0-100 instead of 0-1
+                Text("\(parameter, specifier: "%0.f")%")
+                    .lineLimit(1)
+            } else if units == "Hertz" {
+                Text("\(parameter, specifier: "%0.2f") Hz")
+                    .lineLimit(1)
+            } else {
+                Text("\(parameter, specifier: format) \(units)")
+                    .lineLimit(1)
+            }
+            SmallKnob(value: $parameter, range: range)
+            
+        }.frame(maxWidth: 150, maxHeight: 200).frame(minHeight: 100)
+    }
+}
+
+

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Reusable Components/ParameterRow.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Reusable Components/ParameterRow.swift
@@ -1,0 +1,74 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
+
+import AudioKit
+import Controls
+import SwiftUI
+import CoreMIDI
+
+/// Hack to get SwiftUI to poll and refresh our UI.
+class Refresher: ObservableObject {
+    @Published var version = 0
+}
+
+public struct ParameterRow: View {
+    var param: NodeParameter
+    @StateObject var refresher = Refresher()
+
+    public init(param: NodeParameter) {
+        self.param = param
+    }
+
+    func floatToDoubleRange(_ floatRange: ClosedRange<Float>) -> ClosedRange<Double> {
+        Double(floatRange.lowerBound) ... Double(floatRange.upperBound)
+    }
+
+    func getBinding() -> Binding<Float> {
+        Binding(
+            get: { param.value },
+            set: { param.value = $0; refresher.version += 1}
+        )
+    }
+
+    func getIntBinding() -> Binding<Int> {
+        Binding(get: { Int(param.value) }, set: { param.value = AUValue($0); refresher.version += 1 })
+    }
+
+    func intValues() -> [Int] {
+        Array(Int(param.range.lowerBound) ... Int(param.range.upperBound))
+    }
+    var format: String {
+        if (param.range.upperBound - param.range.lowerBound) > 20 {
+            return "%0.0f"
+        } else {
+            return "%0.2f"
+        }
+    }
+
+    public var body: some View {
+        VStack(alignment: .center) {
+            Text(param.def.name).lineLimit(1)
+            Text("\(String(format: format, param.value))").lineLimit(1)
+
+            switch param.def.unit {
+            case .boolean:
+                Toggle(isOn: Binding(get: { param.value == 1.0 }, set: {
+                    param.value = $0 ? 1.0 : 0.0; refresher.version += 1
+                }), label: { Text(param.def.name) })
+            case .indexed:
+                if param.range.upperBound - param.range.lowerBound < 5 {
+                    Picker(param.def.name, selection: getIntBinding()) {
+                        ForEach(intValues(), id: \.self) { value in
+                            Text("\(value)").tag(value)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                } else {
+                    SmallKnob(value: getBinding(), range: param.range)
+
+                }
+            default:
+                SmallKnob(value: getBinding(), range: param.range)
+            }
+        }.frame(maxWidth: 150, maxHeight: 200).frame(minHeight: 100)
+    }
+}


### PR DESCRIPTION
This PR attempts to improve the UI for smaller devices, most notably replacing AudioKitUI's ParameterEditor2 and ParameterSlider with ParameterRow and CookbookKnob. (I also fixed an issue with the ADSR example needing a start and stop method.)

The problem before is that the multi-line labels were pushing everything around. Now the labels have a line limit but this can result in some longer labels being truncated especially if there are several knobs in a row like the Phaser.

ParameterRow and CookbookKnob could be moved to AudioKitUI but it might be nice to have them in the Cookbook.
