### PR TITLE
Fix Issue 132, crash when navigating back without stopping drum sequencer

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
@@ -119,6 +119,7 @@ struct DrumSequencerView: View {
             conductor.start()
         }
         .onDisappear {
+            conductor.drums.destroyEndpoint()
             conductor.stop()
         }
     }


### PR DESCRIPTION
This fixes issue #132 that I reported earlier.

With this fix, the midi connection is stopped (as far as I understand the underlying method) before actually everything is de-allocated.

I could not crash the app anymore with this fix, tried navigating back and forth starting and stopping a lot of times.