### PR TITLE
[Fix]: Telephone layout + Telephone deletion

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/Telephone.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/Telephone.swift
@@ -201,7 +201,7 @@ struct Phone: View {
         VStack {
             Text(formattedPhoneNumber(conductor.last10Digits))
                 .font(.largeTitle)
-            
+
             VStack(spacing: 20) {
                 HStack(spacing: 20) {
                     NumberKey(mainDigit: "1")
@@ -232,9 +232,9 @@ struct Phone: View {
         }
         .padding()
     }
-    
+
     // MARK: - Phone - Private
-    
+
     private func formattedPhoneNumber(_ digits: String) -> String {
         return digits == "" ? " " : digits
     }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/Telephone.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/Telephone.swift
@@ -8,7 +8,7 @@ import SwiftUI
 class TelephoneConductor: ObservableObject, HasAudioEngine {
     let engine = AudioEngine()
 
-    @Published var last10Digits = " "
+    @Published var last10Digits = ""
 
     let dialTone = OperationGenerator {
         let dialTone1 = Operation.sineWave(frequency: 350)
@@ -165,7 +165,7 @@ struct Phone: View {
             Image(systemName: "phone.fill").font(.largeTitle)
         }
         .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .local).onChanged { _ in
-            if conductor.last10Digits.count > 1 {
+            if conductor.last10Digits.count > 0 {
                 conductor.doit(key: "CALL", state: "down")
             }
         }.onEnded { _ in
@@ -191,7 +191,7 @@ struct Phone: View {
             Image(systemName: "delete.left.fill").font(.largeTitle)
         }
         .gesture(DragGesture(minimumDistance: 0, coordinateSpace: .local).onEnded { _ in
-            if conductor.last10Digits.count > 1 {
+            if conductor.last10Digits.count > 0 {
                 conductor.last10Digits.removeLast()
             }
         })
@@ -199,8 +199,10 @@ struct Phone: View {
 
     var body: some View {
         VStack {
-            Text(conductor.last10Digits).font(.largeTitle)
-            VStack {
+            Text(formattedPhoneNumber(conductor.last10Digits))
+                .font(.largeTitle)
+            
+            VStack(spacing: 20) {
                 HStack(spacing: 20) {
                     NumberKey(mainDigit: "1")
                     NumberKey(mainDigit: "2", alphanumerics: "A B C")
@@ -229,6 +231,12 @@ struct Phone: View {
             }.padding(30)
         }
         .padding()
+    }
+    
+    // MARK: - Phone - Private
+    
+    private func formattedPhoneNumber(_ digits: String) -> String {
+        return digits == "" ? " " : digits
     }
 }
 


### PR DESCRIPTION
This fixes issue https://github.com/AudioKit/Cookbook/issues/143 

**Problem**

On the telephone Cookbook example:

- digits cannot be fully deleted.
- vertical layout is uneven.

**Solution**

- Fix delete + phone call digit gating to check for > 0 characters.
- Set a specific vertical spacing value to enforce a uniform layout.

|Before|After|
|--|--|
|![CleanShot 2024-01-04 at 12 32 36](https://github.com/AudioKit/Cookbook/assets/4419983/b6d198a6-38c3-4682-9c86-f99c435927c4)|![CleanShot 2024-01-04 at 12 30 48](https://github.com/AudioKit/Cookbook/assets/4419983/cbd2c046-ee44-4451-9249-2be372b3c6f8)|



