### PR TITLE
Add midiCallback to DrumSequencer

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
@@ -10,6 +10,7 @@ import SwiftUI
 class DrumSequencerConductor: ObservableObject, HasAudioEngine {
     let engine = AudioEngine()
     let drums = MIDISampler(name: "Drums")
+    var midiCallback = MIDICallbackInstrument()
     let sequencer = AppleSequencer(fromURL: Bundle.module.url(forResource: "MIDI Files/4tracks", withExtension: "mid")!)
 
     @Published var tempo: Float = 120 {
@@ -37,6 +38,13 @@ class DrumSequencerConductor: ObservableObject, HasAudioEngine {
     }
 
     init() {
+        midiCallback.callback = { status, note, velocity in
+            if status == 144 { //Note On
+                self.drums.play(noteNumber: note, velocity: velocity, channel: 0)
+            } else if status == 128 { //Note Off
+                
+            }
+        }
         engine.output = drums
         do {
             let bassDrumURL = Bundle.module.resourceURL?.appendingPathComponent("Samples/bass_drum_C1.wav")
@@ -70,7 +78,7 @@ class DrumSequencerConductor: ObservableObject, HasAudioEngine {
         }
         sequencer.clearRange(start: Duration(beats: 0), duration: Duration(beats: 100))
         sequencer.debug()
-        sequencer.setGlobalMIDIOutput(drums.midiIn)
+        sequencer.setGlobalMIDIOutput(midiCallback.midiIn)
         sequencer.enableLooping(Duration(beats: 4))
         sequencer.setTempo(150)
 

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
@@ -39,10 +39,10 @@ class DrumSequencerConductor: ObservableObject, HasAudioEngine {
 
     init() {
         midiCallback.callback = { status, note, velocity in
-            if status == 144 { //Note On
+            if status == 144 { // Note On
                 self.drums.play(noteNumber: note, velocity: velocity, channel: 0)
-            } else if status == 128 { //Note Off
-                
+            } else if status == 128 { // Note Off
+
             }
         }
         engine.output = drums


### PR DESCRIPTION
In Xcode 15.3 Beta MIDISampler instruments are not responding to MIDI events from AppleSequencer. This issue might only be present in the Beta. As a workaround a MIDICallback instrument is being used. This fix might also need to be applied to the Music Toy example or fixes made to MIDISampler if things are still funky when Xcode 15.3 is released.

Addresses issue: https://github.com/AudioKit/AudioKit/issues/2901