### PR TITLE
Fix Music Toy Recipe

### DIFF
--- a/Cookbook/CookbookCommon/Package.swift
+++ b/Cookbook/CookbookCommon/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [.macOS(.v12), .iOS(.v16), .tvOS(.v15)],
     products: [.library(name: "CookbookCommon", targets: ["CookbookCommon"])],
     dependencies: [
-        .package(url: "https://github.com/AudioKit/AudioKit",          from: "5.6.0"),
+        .package(url: "https://github.com/AudioKit/AudioKit",          from: "5.6.4"),
         .package(url: "https://github.com/AudioKit/AudioKitUI",        branch: "visionos"),
         .package(url: "https://github.com/AudioKit/AudioKitEX",        from: "5.6.0"),
         .package(url: "https://github.com/AudioKit/Controls",          from: "1.0.0"),


### PR DESCRIPTION
This PR updates the AudioKit version in the Cookbook to fix an issue with MIDISampler in Xcode 15.3+. Mentioned here: https://github.com/AudioKit/AudioKit/issues/2901