### PR TITLE
STK Demo: Change the updated beat value to be published on the main thread

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/AdditionalPackages/STKView.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/AdditionalPackages/STKView.swift
@@ -63,8 +63,10 @@ class ShakerConductor: ObservableObject, HasAudioEngine {
         _ = sequencer.addTrack(for: shaker)
 
         callbackInst = CallbackInstrument(midiCallback: { _, beat, _ in
-            self.data.currentBeat = Int(beat)
-            print(beat)
+            DispatchQueue.main.async { [unowned self] in
+                self.data.currentBeat = Int(beat)
+                print(beat)
+            }
         })
 
         _ = sequencer.addTrack(for: callbackInst)


### PR DESCRIPTION
When I start the STK Demo, Xcode displays a warning, saying: 

> Publishing changes from background threads is not allowed; make sure to publish values from the main thread (via operators like receive(on:)) on model updates.

Adding `DispatchQueue.main.async` publishes the new values to the main thread.

<img width="1482" alt="stk-demo-screenshot" src="https://github.com/AudioKit/Cookbook/assets/1577928/c479983c-9ee8-40e0-a8a8-95e26bbaf480">
