### PR TITLE
Updated the background and text colors so that the grid is visible in dark and light mode.

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/AdditionalPackages/PianoRollView.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/AdditionalPackages/PianoRollView.swift
@@ -12,9 +12,15 @@ public struct PianoRollView: View {
     ], length: 128, height: 128)
 
     public var body: some View {
-        ScrollView([.horizontal, .vertical], showsIndicators: true) {
-            PianoRoll(model: $model, noteColor: .cyan, layout: .horizontal)
-        }.background(Color(white: 0.1))
-            .navigationTitle("Piano Roll Demo").foregroundStyle(.white)
+        VStack(alignment: .leading) {
+            Text("Tap inside of the scrolling grid to set a note.")
+                .padding([.top, .horizontal])
+            ScrollView([.horizontal, .vertical], showsIndicators: true) {
+                PianoRoll(model: $model, noteColor: .cyan, gridColor: .primary, layout: .horizontal)
+            }
+            .padding()
+        }
+        .foregroundStyle(.primary)
+        .navigationTitle("Piano Roll Demo")
     }
 }


### PR DESCRIPTION
- Updated the background and text colors so that the grid is visible in dark and light mode. 
- Also added instructional text to make the demo more user friendly

<img src="https://github.com/AudioKit/Cookbook/assets/1577928/53a05788-d5ed-46d5-a63c-496eed53167b" width="50%" height="50%" />

<img src="https://github.com/AudioKit/Cookbook/assets/1577928/ee7c4193-0aef-40ad-85f1-2766b792f025" width="50%" height="50%" />

<br />
<br />

**Current Piano Roll Demo View in light mode:**

<img src="https://github.com/AudioKit/Cookbook/assets/1577928/cbba9ca5-1e01-47dc-ada7-cd73d738268c" width="50%" height="50%" />

**Current Piano Roll Demo View in dark mode:**

<img src="https://github.com/AudioKit/Cookbook/assets/1577928/3a446dc5-dd5b-4831-a780-9f7af18c6c3b" width="50%" height="50%" />

