### PR TITLE
Update Settings.sampleRate for iOS 18

### DIFF
--- a/Cookbook/Cookbook/CookbookApp.swift
+++ b/Cookbook/Cookbook/CookbookApp.swift
@@ -11,14 +11,13 @@ struct CookbookApp: App {
         #if os(iOS)
             do {
                 Settings.bufferLength = .short
-                
+
                 let deviceSampleRate = AVAudioSession.sharedInstance().sampleRate
                 if deviceSampleRate > Settings.sampleRate {
                     // Update sampleRate to 48_000. Default is 44_100.
                     Settings.sampleRate = deviceSampleRate
                 }
-                
-                
+
                 try AVAudioSession.sharedInstance().setPreferredIOBufferDuration(Settings.bufferLength.duration)
                 try AVAudioSession.sharedInstance().setCategory(.playAndRecord,
                                                                 options: [.defaultToSpeaker, .mixWithOthers, .allowBluetoothA2DP])

--- a/Cookbook/Cookbook/CookbookApp.swift
+++ b/Cookbook/Cookbook/CookbookApp.swift
@@ -11,6 +11,14 @@ struct CookbookApp: App {
         #if os(iOS)
             do {
                 Settings.bufferLength = .short
+                
+                let deviceSampleRate = AVAudioSession.sharedInstance().sampleRate
+                if deviceSampleRate > Settings.sampleRate {
+                    // Update sampleRate to 48_000. Default is 44_100.
+                    Settings.sampleRate = deviceSampleRate
+                }
+                
+                
                 try AVAudioSession.sharedInstance().setPreferredIOBufferDuration(Settings.bufferLength.duration)
                 try AVAudioSession.sharedInstance().setCategory(.playAndRecord,
                                                                 options: [.defaultToSpeaker, .mixWithOthers, .allowBluetoothA2DP])

--- a/Cookbook/CookbookCommon/Package.swift
+++ b/Cookbook/CookbookCommon/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/AudioKit/Waveform",          branch: "visionos"),
         .package(url: "https://github.com/AudioKit/Flow",              from: "1.0.0"),
         .package(url: "https://github.com/AudioKit/PianoRoll",         from: "1.0.0"),
-        .package(url: "https://github.com/orchetect/MIDIKit",          from: "0.9.4"),
+        .package(url: "https://github.com/orchetect/MIDIKit",          from: "0.9.7"),
     ],
     targets: [
         .target(

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSequencer.swift
@@ -127,6 +127,7 @@ struct DrumSequencerView: View {
             conductor.start()
         }
         .onDisappear {
+            conductor.isPlaying = false
             conductor.drums.destroyEndpoint()
             conductor.stop()
         }

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSynthesizers.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/DrumSynthesizers.swift
@@ -64,6 +64,7 @@ struct DrumSynthesizersView: View {
             conductor.start()
         }
         .onDisappear {
+            conductor.isRunning = false
             conductor.stop()
         }
     }


### PR DESCRIPTION
In iOS 18, the default device sample rate goes from 44_100 to 48_000. This PR checks the AVAudioSession's sampleRate and updates Settings.sampleRate if needed (current default is 44_100).

Additionally, this change could be applied to how the value is initialized in the Settings class of the AudioKit package. 