### PR TITLE
Update Settings.samplerRate in iOS 18 and newer to 48_000

### DIFF
--- a/Cookbook/Cookbook/CookbookApp.swift
+++ b/Cookbook/Cookbook/CookbookApp.swift
@@ -12,10 +12,9 @@ struct CookbookApp: App {
             do {
                 Settings.bufferLength = .short
 
-                let deviceSampleRate = AVAudioSession.sharedInstance().sampleRate
-                if deviceSampleRate > Settings.sampleRate {
-                    // Update sampleRate to 48_000. Default is 44_100.
-                    Settings.sampleRate = deviceSampleRate
+                // Settings.sampleRate default is 44_100
+                if #available(iOS 18.0, *) {
+                    Settings.sampleRate = 48_000
                 }
 
                 try AVAudioSession.sharedInstance().setPreferredIOBufferDuration(Settings.bufferLength.duration)


### PR DESCRIPTION
The required sampleRate for mic inputs in iOS 18 appears to have changed from 44_100 to 48_000. This PR addresses that. If this becomes a permanent solution it should be added to the AudioKit Swift Package.