### PR TITLE
Add SFZ Load Delay

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/InstrumentSFZ.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/InstrumentSFZ.swift
@@ -23,7 +23,8 @@ class InstrumentSFZConductor: ObservableObject, HasAudioEngine {
     init() {
         DispatchQueue.main.async {
             // Load SFZ file with Dunne Sampler.
-            // This needs to be loaded after a delay the first time to get the correct Settings.sampleRate if it is 48_000.
+            // This needs to be loaded after a delay the first time
+            // to get the correct Settings.sampleRate if it is 48_000.
             if let fileURL = Bundle.main.url(forResource: "Sounds/sqr", withExtension: "SFZ") {
                 self.instrument.loadSFZ(url: fileURL)
             } else {

--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/InstrumentSFZ.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/InstrumentSFZ.swift
@@ -21,13 +21,16 @@ class InstrumentSFZConductor: ObservableObject, HasAudioEngine {
     }
     
     init() {
-        // Load SFZ file with Dunne Sampler
-        if let fileURL = Bundle.main.url(forResource: "Sounds/sqr", withExtension: "SFZ") {
-            instrument.loadSFZ(url: fileURL)
-        } else {
-            Log("Could not find file")
+        DispatchQueue.main.async {
+            // Load SFZ file with Dunne Sampler.
+            // This needs to be loaded after a delay the first time to get the correct Settings.sampleRate if it is 48_000.
+            if let fileURL = Bundle.main.url(forResource: "Sounds/sqr", withExtension: "SFZ") {
+                self.instrument.loadSFZ(url: fileURL)
+            } else {
+                Log("Could not find file")
+            }
+            self.instrument.masterVolume = 0.15
         }
-        instrument.masterVolume = 0.15
         engine.output = instrument
     }
 }


### PR DESCRIPTION
To get the correct Settings.samplerRate passed to Sampler (48_000) we need to add a delay the first time that it is loaded. This was introduced in iOS 18 when the system's default sampleRate changed from 44_100 to 48_000. At some point we can change the default of Sampler's sampleRate to be 48_000.