### PR TITLE
Update Mac Sample Rate

### DIFF
--- a/Cookbook/Cookbook/CookbookApp.swift
+++ b/Cookbook/Cookbook/CookbookApp.swift
@@ -20,8 +20,8 @@ struct CookbookApp: App {
                     }
                 }
                 if #available(macOS 15.0, *) {
-                    // Set samplerRate for macOS 15 and newer
-                    Settings.sampleRate = 48_000
+                    // Set samplerRate for macOS 15 and newer (reverted back to 44_100)
+                    Settings.sampleRate = 44_100
                 }
 
                 try AVAudioSession.sharedInstance().setPreferredIOBufferDuration(Settings.bufferLength.duration)


### PR DESCRIPTION
Reverted the Default Sample Rate to 44_100. It had been changed to 48_000 at the start of macOS 15 but now 44_100 seems to be working again. Your apps should account for both if you are doing audio recordings.