### PR TITLE
Refactor MiniApps/Arpeggiator

### DIFF
--- a/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/Arpeggiator.swift
+++ b/Cookbook/CookbookCommon/Sources/CookbookCommon/Recipes/MiniApps/Arpeggiator.swift
@@ -47,19 +47,19 @@ class ArpeggiatorConductor: ObservableObject, HasAudioEngine {
         }
         
         if !isArpDescending {
-          if heldNotes.max() != currentNote {
-            currentNote = heldNotes.filter { $0 > currentNote }.min() ?? heldNotes.min()!
-          } else {
-            isArpDescending = true
-            currentNote = heldNotes.filter { $0 < currentNote }.max() ?? heldNotes.max()!
-          }
+            if heldNotes.max() != currentNote {
+                currentNote = heldNotes.filter { $0 > currentNote }.min() ?? heldNotes.min()!
+            } else {
+                isArpDescending = true
+                currentNote = heldNotes.filter { $0 < currentNote }.max() ?? heldNotes.max()!
+            }
         } else {
-          if heldNotes.min() != currentNote {
-            currentNote = heldNotes.filter { $0 < currentNote }.max() ?? heldNotes.max()!
-          } else {
-            isArpDescending = false
-            currentNote = heldNotes.filter { $0 > currentNote }.min() ?? heldNotes.min()!
-          }
+            if heldNotes.min() != currentNote {
+                currentNote = heldNotes.filter { $0 < currentNote }.max() ?? heldNotes.max()!
+            } else {
+                isArpDescending = false
+                currentNote = heldNotes.filter { $0 > currentNote }.min() ?? heldNotes.min()!
+            }
         }
         
         instrument.play(noteNumber: MIDINoteNumber(currentNote), velocity: 120, channel: 0)


### PR DESCRIPTION
First of all, thank you for creating such a great example app for studying AudioKit. While looking at the code, I think there are some parts that could be more efficient, so I'd like to propose a PR. I appreciate your time and consideration.
- rename variable `arpUp` to `isArpDescending` 
- Simplified `fireTimer()`
- Simplified `noteOff(pitch:)

---

### 1. Improved arpeggio direction logic

The original `arpUp` variable name was misleading, as its logic handled descending movement when `true`, and ascending when `false`. It’s been renamed to `isArpDescending` for clarity and to better reflect its actual behavior.

Unnecessary use of an intermediate `tempArray` was removed—since `heldNotes` is a value type and isn’t mutated, copying was redundant. Also, assigning directly to `currentNote` eliminates the need for a temporary `arrayValue`. Lastly, replacing `sorted().first(where:)` and `last(where:)` with `filter().min()` and `max()` results in cleaner and more efficient code.

---

### 2. Simplified `noteOff(pitch:)`

The original loop over `heldNotes` repeatedly applied `filter` inside the loop, which was inefficient. It's now replaced with a single `filter` call that removes the matching note in one step:

```swift
heldNotes = heldNotes.filter { $0 != pitch.intValue }
```
